### PR TITLE
OpenAthens golive nga1 University of North Georgia

### DIFF
--- a/prod-organisations.csv
+++ b/prod-organisations.csv
@@ -3045,7 +3045,6 @@ Governor's Office,usg-gov1,https://www.galileo.usg.edu/wayfinder/usg-gov1-govern
 Georgia Student Finance Commission,usg-gsfc,https://www.galileo.usg.edu/wayfinder/usg-gsfc-georgia-student-finance-commission
 Georgia Gwinnett College,usg-gwin,https://www.galileo.usg.edu/wayfinder/usg-gwin-georgia-gwinnett-college
 Kennesaw State University,usg-ken1,https://www.galileo.usg.edu/wayfinder/usg-ken1-kennesaw-state-university
-University of North Georgia,usg-nga1,https://www.galileo.usg.edu/wayfinder/usg-nga1-university-of-north-georgia
 Office of Planning and Budget,usg-opb1,https://www.galileo.usg.edu/wayfinder/usg-opb1-office-of-planning-and-budget
 Augusta University,usg-reg1,https://www.galileo.usg.edu/wayfinder/usg-reg1-augusta-university
 General Assembly,usg-sen1,https://www.galileo.usg.edu/wayfinder/usg-sen1-general-assembly


### PR DESCRIPTION
In other words, University of North Georgia has been removed from the non-fed-orgs list.