### PR TITLE
OpenAthens golive for val1 Valdosta

### DIFF
--- a/prod-organisations.csv
+++ b/prod-organisations.csv
@@ -3052,4 +3052,3 @@ Southern Regional Education Board,usg-sre1,https://www.galileo.usg.edu/wayfinder
 University of Georgia,usg-uga1,http://www.libs.uga.edu/galileologin.html
 University of Georgia School of Law,usg-uga1:,http://www.libs.uga.edu/galileologin.html
 University System - Test Site,usg-usys,https://www.galileo.usg.edu/wayfinder/usg-usys-university-system-test-site
-Valdosta State University,usg-val1,https://www.galileo.usg.edu/wayfinder/usg-val1-valdosta-state-university


### PR DESCRIPTION
In other words, Valdosta State University no long included in the non-fed-orgs list.